### PR TITLE
fix deprecated vars

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -6,7 +6,7 @@
 
 - name: Install the ddclient packages 
   apt: name={{ item }} state=present
-  with_items: ddclient_ubuntu_pkg
+  with_items: "{ ddclient_ubuntu_pkg }"
   when: ansible_os_family == "Debian"
 
 - name: ddclient | Set ddclient config 


### PR DESCRIPTION
`tasks/main.yml` references a variable in a manner that will be deprecated in the future.

Deprecation Warning:

```
TASK [jgrowl.ddclient : Install the ddclient packages] *************************
[DEPRECATION WARNING]: Using bare variables is deprecated. Update your 
playbooks so that the environment value uses the full variable syntax 
('{{ddclient_ubuntu_pkg}}'). This feature will be removed in a future release. 
Deprecation warnings can be disabled by setting deprecation_warnings=False in 
ansible.cfg.
```
